### PR TITLE
Learn rebrand and linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The **official, default** template at Microsoft is the one called **mit**.  If y
 files in the `shared/` folder with the files in `projections/mit`, you get the standard, default
 set of files that new GitHub repos are placed with in the company.
 
-# What is this?
+## What is this?
 
 These files are packaged as the default, standard recommended content for net new
 GitHub repos created by Microsoft teams across all official Microsoft GitHub orgs such
@@ -61,7 +61,7 @@ feedback, but not host or store code.
 
 ### microsoft.docs
 
-Default template for docs-related repos that are used by the https://docs.microsoft.com site.
+Default template for docs-related repos that are used by the <https://learn.microsoft.com> site.
 
 ### mit
 
@@ -70,7 +70,7 @@ basics such as a `SECURITY.MD` file.
 
 ### official-sample-dnf
 
-Official samples that are indexed at https://docs.microsoft.com/samples and also are copyright-assigned 
+Official samples that are indexed at <https://learn.microsoft.com/samples> and also are copyright-assigned
 to the .NET Foundation use this template.
 
 The `README.md` file has a rich metadata header with required fields and information that is processed
@@ -81,7 +81,7 @@ connects with a sample publishing system.
 
 ### official-sample-microsoft
 
-Official samples that are indexed at https://docs.microsoft.com/samples.
+Official samples that are indexed at <https://learn.microsoft.com/samples>.
 
 The `README.md` file has a rich metadata header with required fields and information that is processed
 by the docs site. The template outlines some of the files that are placed.
@@ -107,7 +107,7 @@ These are more specific templates for projects such as Microsoft official sample
 
 ## Output of the union of the directories
 
-```
+```text
 // psuedo-code
 for (each templateName of projections) {
   copy(sharedFiles, excludingAnySpecialExclusions);
@@ -115,11 +115,11 @@ for (each templateName of projections) {
 }
 ```
 
-# Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.
 
-## Pull request review
+### Pull request review
 
 Pull requests to this repo will be reviewed, at a minimum, by the Open Source Programs Office at
 Microsoft, as well as a set of Microsoft's "Open Source Champs", for guidance.
@@ -128,7 +128,7 @@ Please understand that these templates often need to be kept rather simple, sinc
 they are a starting point, and if there is too much guidance, teams may not be familiar
 with how to react and manage projects with too much initial content.
 
-## Contribution requirements
+### Contribution requirements
 
 Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ with how to react and manage projects with too much initial content.
 
 Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ feedback, but not host or store code.
 
 ### microsoft.docs
 
-Default template for docs-related repos that are used by the <https://learn.microsoft.com> site.
+Default template for docs-related repos that are used by the [Microsoft Learn](https://learn.microsoft.com) site.
 
 ### mit
 
@@ -70,7 +70,7 @@ basics such as a `SECURITY.MD` file.
 
 ### official-sample-dnf
 
-Official samples that are indexed at <https://learn.microsoft.com/samples> and also are copyright-assigned
+Official samples that are indexed at Microsoft Learn's [code samples](https://learn.microsoft.com/samples) and also are copyright-assigned
 to the .NET Foundation use this template.
 
 The `README.md` file has a rich metadata header with required fields and information that is processed
@@ -81,7 +81,7 @@ connects with a sample publishing system.
 
 ### official-sample-microsoft
 
-Official samples that are indexed at <https://learn.microsoft.com/samples>.
+Official samples that are indexed at Microsoft Learn's [code samples](https://learn.microsoft.com/samples).
 
 The `README.md` file has a rich metadata header with required fields and information that is processed
 by the docs site. The template outlines some of the files that are placed.
@@ -132,7 +132,7 @@ with how to react and manage projects with too much initial content.
 
 Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions

--- a/projections/azure-samples/CONTRIBUTING.md
+++ b/projections/azure-samples/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
   * Rebase your fork and force push to your GitHub repository (this will update your Pull Request):
 
     ```shell
-    git rebase master -i
+    git rebase main -i
     git push -f
     ```
 

--- a/projections/azure-samples/CONTRIBUTING.md
+++ b/projections/azure-samples/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -51,12 +51,12 @@ chances of your issue being dealt with quickly:
 * **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
   causing the problem (line of code or commit)
 
-You can file new issues by providing the above information at the corresponding repository's issues link: https://github.com/[organization-name]/[repository-name]/issues/new].
+You can file new issues by providing the above information at the corresponding repository's issues link: <https://github.com/[organization-name]/[repository-name]/issues/new>.
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-* Search the repository (https://github.com/[organization-name]/[repository-name]/pulls) for an open or closed PR
+* Search the repository (<https://github.com/[organization-name]/[repository-name]/pulls>) for an open or closed PR
   that relates to your submission. You don't want to duplicate effort.
 
 * Make your changes in a new git fork:

--- a/projections/azure-samples/CONTRIBUTING.md
+++ b/projections/azure-samples/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -51,12 +51,12 @@ chances of your issue being dealt with quickly:
 * **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
   causing the problem (line of code or commit)
 
-You can file new issues by providing the above information at the corresponding repository's issues link: <https://github.com/[organization-name]/[repository-name]/issues/new>.
+You can file new issues by providing the above information at the corresponding repository's issues link: [Create new issue](https://github.com/[organization-name]/[repository-name]/issues/new).
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-* Search the repository (<https://github.com/[organization-name]/[repository-name]/pulls>) for an open or closed PR
+* Search the repository's [pull requests](https://github.com/[organization-name]/[repository-name]/pulls) for an open or closed PR
   that relates to your submission. You don't want to duplicate effort.
 
 * Make your changes in a new git fork:

--- a/projections/azure-samples/CONTRIBUTING.md
+++ b/projections/azure-samples/CONTRIBUTING.md
@@ -51,7 +51,9 @@ chances of your issue being dealt with quickly:
 * **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
   causing the problem (line of code or commit)
 
-You can file new issues by providing the above information at the corresponding repository's issues link: [Create new issue](https://github.com/[organization-name]/[repository-name]/issues/new).
+You can file new issues by providing the above information at the corresponding repository's issues link: 
+replace`[organization-name]` and `[repository-name]` in
+`https://github.com/[organization-name]/[repository-name]/issues/new` .
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:

--- a/projections/dnfmit.docs/README.md
+++ b/projections/dnfmit.docs/README.md
@@ -14,9 +14,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
 
-Privacy information can be found at https://privacy.microsoft.com/en-us/
+Privacy information can be found at <https://privacy.microsoft.com>.
 
 .NET Foundation and any contributors reserve all other rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/projections/dnfmit.docs/README.md
+++ b/projections/dnfmit.docs/README.md
@@ -14,9 +14,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
+Microsoft's general trademark guidelines can be found at [Microsoft Trademark and Brand Guidelines](http://go.microsoft.com/fwlink/?LinkID=254653).
 
-Privacy information can be found at <https://privacy.microsoft.com>.
+Privacy information can be found at [https://privacy.microsoft.com](https://privacy.microsoft.com).
 
 .NET Foundation and any contributors reserve all other rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/projections/issueonly/README.md
+++ b/projections/issueonly/README.md
@@ -25,9 +25,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
 
-Privacy information can be found at https://privacy.microsoft.com/en-us/
+Privacy information can be found at <https://privacy.microsoft.com>.
 
 Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/projections/issueonly/README.md
+++ b/projections/issueonly/README.md
@@ -25,9 +25,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
+Microsoft's general trademark guidelines can be found at [Microsoft Trademark and Brand Guidelines](http://go.microsoft.com/fwlink/?LinkID=254653).
 
-Privacy information can be found at <https://privacy.microsoft.com>.
+Privacy information can be found at [https://privacy.microsoft.com](https://privacy.microsoft.com).
 
 Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/projections/issueonly/SUPPORT
+++ b/projections/issueonly/SUPPORT
@@ -2,7 +2,7 @@ Looking for support for a Microsoft product or service?
 
 Consider some of these resources:
 
-- Microsoft Support resources at [https://support.microsoft.com/](https://support.microsoft.com/)
-- Microsoft documentation, samples and more at [https://docs.microsoft.com](https://docs.microsoft.com)
+- Microsoft Support resources at <https://support.microsoft.com>.
+- Microsoft documentation, samples and more at <https://learn.microsoft.com>.
 
 Online forums are also often very helpful.

--- a/projections/issueonly/SUPPORT
+++ b/projections/issueonly/SUPPORT
@@ -2,7 +2,7 @@ Looking for support for a Microsoft product or service?
 
 Consider some of these resources:
 
-- Microsoft Support resources at <https://support.microsoft.com>.
-- Microsoft documentation, samples and more at <https://learn.microsoft.com>.
+- Support resources at [Microsoft Support](https://support.microsoft.com).
+- Microsoft documentation, samples and more at [Microsoft Learn](https://learn.microsoft.com).
 
 Online forums are also often very helpful.

--- a/projections/microsoft.docs/README.md
+++ b/projections/microsoft.docs/README.md
@@ -3,7 +3,7 @@
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -23,9 +23,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
+Microsoft's general trademark guidelines can be found at [Microsoft Trademark and Brand Guidelines](http://go.microsoft.com/fwlink/?LinkID=254653).
 
-Privacy information can be found at <https://privacy.microsoft.com>.
+Privacy information can be found at [https://privacy.microsoft.com](https://privacy.microsoft.com).
 
 Microsoft and any contributors reserve all other rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/projections/microsoft.docs/README.md
+++ b/projections/microsoft.docs/README.md
@@ -3,7 +3,7 @@
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -23,9 +23,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
 
-Privacy information can be found at https://privacy.microsoft.com/en-us/
+Privacy information can be found at <https://privacy.microsoft.com>.
 
 Microsoft and any contributors reserve all other rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/projections/mit/README.md
+++ b/projections/mit/README.md
@@ -14,7 +14,7 @@ As the maintainer of this project, please make a few updates:
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions

--- a/projections/mit/README.md
+++ b/projections/mit/README.md
@@ -14,7 +14,7 @@ As the maintainer of this project, please make a few updates:
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -26,8 +26,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/projections/official-sample-dnf/README.md
+++ b/projections/official-sample-dnf/README.md
@@ -11,11 +11,11 @@ urlFragment: "update-this-to-unique-url-stub"
 # Official .NET Foundation Sample
 
 <!-- 
-Guidelines on README format: https://review.docs.microsoft.com/help/onboard/admin/samples/concepts/readme-template?branch=master
+Guidelines on README format: https://review.learn.microsoft.com/help/contribute/samples/concepts/readme-template?branch=main
 
-Guidance on onboarding samples to docs.microsoft.com/samples: https://review.docs.microsoft.com/help/onboard/admin/samples/process/onboarding?branch=master
+Guidance on onboarding samples to learn.microsoft.com/samples: https://review.learn.microsoft.com/help/contribute/samples/process/onboarding?branch=main
 
-Taxonomies for products and languages: https://review.docs.microsoft.com/new-hope/information-architecture/metadata/taxonomies?branch=master
+Taxonomies for products and languages: https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main
 -->
 
 Give a short description for your sample here. What does it do and why is it important?

--- a/projections/official-sample-microsoft/README.md
+++ b/projections/official-sample-microsoft/README.md
@@ -53,7 +53,7 @@ Provide users with more context on the tools and services used in the sample. Ex
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions

--- a/projections/official-sample-microsoft/README.md
+++ b/projections/official-sample-microsoft/README.md
@@ -11,11 +11,11 @@ urlFragment: "update-this-to-unique-url-stub"
 # Official Microsoft Sample
 
 <!-- 
-Guidelines on README format: https://review.docs.microsoft.com/help/onboard/admin/samples/concepts/readme-template?branch=master
+Guidelines on README format: https://review.learn.microsoft.com/help/contribute/samples/concepts/readme-template?branch=main
 
-Guidance on onboarding samples to docs.microsoft.com/samples: https://review.docs.microsoft.com/help/onboard/admin/samples/process/onboarding?branch=master
+Guidance on onboarding samples to learn.microsoft.com/samples: https://review.learn.microsoft.com/help/contribute/samples/process/onboarding?branch=main
 
-Taxonomies for products and languages: https://review.docs.microsoft.com/new-hope/information-architecture/metadata/taxonomies?branch=master
+Taxonomies for products and languages: https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main
 -->
 
 Give a short description for your sample here. What does it do and why is it important?

--- a/projections/official-sample-microsoft/README.md
+++ b/projections/official-sample-microsoft/README.md
@@ -53,7 +53,7 @@ Provide users with more context on the tools and services used in the sample. Ex
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions


### PR DESCRIPTION
* Fix legacy <https://docs.microsoft.com> references (now <https://learn.microsoft.com>) to avoid a redirect.
* Remove `en-us/` from URLs for better accessibility.
* Put raw URLs in \[]() syntax (was: \<> until review feedback suggested otherwise)
* a few `master` -> `main` updates
* A couple of H2/3 adjustments for proper nesting.